### PR TITLE
add ResponseCode to ini struct for optional HTTP status code required…

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ type Config struct {
 		Md5Input         string
 		Base64Input      string
 		MustCapture      string
+		ResponseCode     string
 		ReqHeaders       []string
 		SessionVar       []string
 		//GrepVar          []string

--- a/goRunner_test.go
+++ b/goRunner_test.go
@@ -109,6 +109,8 @@ func Landing(w http.ResponseWriter, r *http.Request) {
 func HandleToken(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	access_type := r.FormValue("access_type")
+	username, _, ok := r.BasicAuth()
+	authOk := ok == true && username == "ab4c4e00-d8a6-11e4-a96c-34fb509c20ca"
 
 	response := ""
 	switch access_type {
@@ -116,6 +118,10 @@ func HandleToken(w http.ResponseWriter, r *http.Request) {
 		response = "{\"access_token\":\"babd1aed-2e5b-40bb-a53f-d31d69d8571a\",\"refresh_token\":\"a77a8bfe-e9e6-4009-90f8-3e817685fed9\",\"token_type\":\"Carier\",\"expires_in\":3599,\"scope\":\"DEFAULT_SCOPE\"}"
 	case "refresh_token":
 		response = "{\"access_token\":\"babd1aed-2e5b-40bb-a53f-d31d69d8571a\",\"refresh_token\":\"a77a8bfe-e9e6-4009-90f8-3e817685fed9\",\"token_type\":\"Carier\",\"expires_in\":3599,\"scope\":\"DEFAULT_SCOPE\"}"
+	}
+
+	if !authOk {
+		w.WriteHeader(401)
 	}
 	fmt.Fprintf(w, "%v\n", response)
 }

--- a/runner.go
+++ b/runner.go
@@ -708,7 +708,12 @@ func (runner *Runner) doLog(command string, config *Config, requestMethod string
 		runner.foundAllSessionVars = runner.foundAllSessionVars && foundSessionVars
 		continueSession = continueSession && foundMustCaptures
 
-		if httpResponse.StatusCode >= 200 && httpResponse.StatusCode < 400 { //was300
+		successStatus := httpResponse.StatusCode >= 200 && httpResponse.StatusCode < 400
+		expectedStatus := config.FieldInteger("ResponseCode", command)
+		if expectedStatus > 0 {
+			successStatus = httpResponse.StatusCode == expectedStatus
+		}
+		if successStatus {
 			atomic.AddInt32(&result.success, 1) //atomic++
 		} else {
 			atomic.AddInt32(&result.badFailed, 1) //atomic++

--- a/test_public.ini
+++ b/test_public.ini
@@ -10,13 +10,20 @@
 #cant store data at section "command", subsection "asset_id", variable "DoGrep1"
 #this shows the order of the api calls you want the tool to run
 [commandSequence]
-Sequence = check_token, refresh_token, ticket, asset_id, landing, session
+Sequence = invalid_auth, check_token, refresh_token, ticket, asset_id, landing, session
 
 #default values that carry over to all the api call definitions below
 [command "default"]
 ReqType = POST
 ReqContentType = application/x-www-form-urlencoded
 MsecDelay = 1
+
+[command "invalid_auth"]
+ReqUrl = /reqapi/check/token
+ReqHeaders = Authorization: Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==
+ReqHeaders = auth-request-check: eyJwdWxzZVNlcnZlciI6ICJodHRwczovL2FwaS1kci5hZHRwdWxzZS5jb20iLCAiZGV2aWNlU2VjcmV0IjoiZDkzZjczOTktMGRlYy00NjUyLTg1NjgtNzc2OGNhNjIwOWU3In0=
+ReqBody = access_type=password&password={%ARGS[0]}&username={%ARGS[0]}
+ResponseCode = 401
 
 #first api to call
 [command "check_token"]


### PR DESCRIPTION
Optional HTTP status code which will be the expected status code for an API response. If left unset, 2xx/3xx status codes are success and 400+ are failures. This allows testing invalid credentials with an expected 401 Unauthorized response code, for example, to be counted as a successful API call.